### PR TITLE
Adding commandt to the list to be executed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help:
 	@echo "install - install + compile native things."
 	@echo "update  - Download update for all plugins."
 
-install: symlink submodules fonts bye
+install: symlink submodules commandt fonts bye
 
 symlink:
 	ln -sf "$(shell readlink -f "src/vimrc")" ~/.vimrc


### PR DESCRIPTION
You created the block of the command to install the plugin Command-T but you didn't put the identifier in the list of the install command, so i inserted it there.
